### PR TITLE
feat(playground): add many playground sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,20 @@
 
 ## Playgrounds:
 
+- [Codeanywhere](https://codeanywhere.com/)
 - [Codepen](https://codepen.io/your-work)
 - [CodeSandbox](https://codesandbox.io/)
 - [CodiLink](https://codi.link/)
+- [DartPad](https://dartpad.dev/)
 - [Glitch](https://glitch.com/)
+- [Go Playground](https://play.golang.org/)
+- [Google Colab](https://colab.research.google.com/)
+- [JS Bin](https://jsbin.com/)
 - [JSFiddle](https://jsfiddle.net/)
+- [Kotlin Playground](https://play.kotlinlang.org/)
 - [PlayCode](https://playcode.io/)
+- [Replit](https://repl.it/)
+- [Rust Playground](https://play.rust-lang.org/)
 - [StackBlitz](https://stackblitz.com/)
 
 ## Code Editors:


### PR DESCRIPTION
Hi 😀 Thank you for making this repo. 😅
This PR is adding many playground site

- [Codeanywhere](https://codeanywhere.com/)
- [DartPad](https://dartpad.dev/)
- [Go Playground](https://play.golang.org/)
- [Google Colab](https://colab.research.google.com/)
- [JS Bin](https://jsbin.com/)
- [Kotlin Playground](https://play.kotlinlang.org/)
- [Replit](https://repl.it/)
- [Rust Playground](https://play.rust-lang.org/)

![image](https://user-images.githubusercontent.com/11144228/137636812-75aa9920-8b23-47a1-a37c-dee9e6c9846a.png)
